### PR TITLE
Impl default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub fn is_leap_year(year: i32) -> bool {
     } else if year % 100 > 0 {
         true
     } else {
-         year % 400 == 0 
+        year % 400 == 0
     }
 }
 
@@ -76,7 +76,7 @@ pub fn is_end_of_month(day: u32, month: u32, year: i32) -> bool {
     }
 }
 
-#[derive(Hash, Clone, Copy, Debug)]
+#[derive(Hash, Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum DayCountConvention {
@@ -337,6 +337,12 @@ impl FromStr for DayCountConvention {
     }
 }
 
+impl Default for DayCountConvention {
+    fn default() -> Self {
+        DayCountConvention::US30360
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum DayCountConventionError {
     #[error("Yearfrac: Invalid Value: {}. Has to be one of: nasd30/360, act/act, act360, act365, eur30/360 (from_str) 
@@ -345,4 +351,11 @@ pub enum DayCountConventionError {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default() {
+        assert_eq!(DayCountConvention::default(), DayCountConvention::US30360)
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -11,6 +11,9 @@ fn test_accuracy() {
         .unwrap()
         .yearfrac(start, end);
     assert!((yf - 42.21388888889).abs() < delta);
+    let yf = DayCountConvention::default()
+        .yearfrac(start, end);
+    assert!((yf - 42.21388888889).abs() < delta);      
     let yf = DayCountConvention::from_int(1)
         .unwrap()
         .yearfrac(start, end);
@@ -34,6 +37,8 @@ fn test_accuracy() {
         .unwrap()
         .yearfrac(start, end);
     assert!((yf - 28.37777777778).abs() < delta);
+    let yf = DayCountConvention::default().yearfrac(start, end);
+    assert!((yf - 28.37777777778).abs() < delta);    
     let yf = DayCountConvention::from_str("act/act")
         .unwrap()
         .yearfrac(start, end);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -11,9 +11,8 @@ fn test_accuracy() {
         .unwrap()
         .yearfrac(start, end);
     assert!((yf - 42.21388888889).abs() < delta);
-    let yf = DayCountConvention::default()
-        .yearfrac(start, end);
-    assert!((yf - 42.21388888889).abs() < delta);      
+    let yf = DayCountConvention::default().yearfrac(start, end);
+    assert!((yf - 42.21388888889).abs() < delta);
     let yf = DayCountConvention::from_int(1)
         .unwrap()
         .yearfrac(start, end);
@@ -38,7 +37,7 @@ fn test_accuracy() {
         .yearfrac(start, end);
     assert!((yf - 28.37777777778).abs() < delta);
     let yf = DayCountConvention::default().yearfrac(start, end);
-    assert!((yf - 28.37777777778).abs() < delta);    
+    assert!((yf - 28.37777777778).abs() < delta);
     let yf = DayCountConvention::from_str("act/act")
         .unwrap()
         .yearfrac(start, end);


### PR DESCRIPTION
I'd like to implement default. It's useful for creating tests where you have a struct that has a field of type DayCountConvention and for setting a default value when its used as part of an app, in my case as the default value for a CLI arg with Clap. 

(the removal of the spaces in src/lib.rs was done by cargo fmt, I couldnt see a reason not to leave it in). 

Lib works great btw, thanks for making it!